### PR TITLE
implement invitations controller spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 
 # Ignore application configuration
 /config/application.yml
+
+# ignore rubocop linting config
+.rubocop.yml

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,3 @@
 
 # Ignore application configuration
 /config/application.yml
-
-# ignore rubocop linting config
-.rubocop.yml

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -88,7 +88,7 @@ class InvitationsController < ApplicationController
     @user = @invitation.receiver
     if @user.team_id
       respond_to do |format|
-        format.html { redirect_to 'users/me', notice: 'You are already on a team' }
+        format.html { redirect_to users_me_path, notice: 'You are already on a team' }
         format.json { render :show, status: :ok, location: @user }
       end
     else

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+describe InvitationsController do
+  before(:each) do
+    @invitation = create(:invitation)
+    sign_in @invitation.receiver
+  end
+
+  describe 'GET #index' do
+    it 'is successful' do
+      get :index
+
+      expect(response).to be_success
+      expect(response).to render_template :index
+    end
+  end
+
+  describe 'GET #show' do
+    it 'is successful' do
+      get :show, id: @invitation.id
+
+      expect(response).to be_success
+      expect(response).to render_template :show
+    end
+  end
+
+  describe 'GET #new' do
+    it 'is successful' do
+      get :new
+
+      expect(response).to be_success
+      expect(response).to render_template :new
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'is successful' do
+      get :edit, id: @invitation.id
+
+      expect(response).to be_success
+      expect(response).to render_template :edit
+    end
+  end
+
+  describe 'POST #create' do
+    it 'creates a new invitation' do
+      team = create(:team)
+      invitation = attributes_for(:invitation).merge(sender_id: team.id)
+
+      expect{ post(:create, invitation: invitation) }
+        .to change{ Invitation.count }.by(1)
+      expect(response).to redirect_to team
+    end
+  end
+
+  describe 'PATCH #update' do
+    it 'is successful' do
+      new_message = 'We would really love for you to join our team!'
+      invitation_update = lambda do
+        patch(:update, id: @invitation.id, invitation: { mssg: new_message })
+      end
+
+      expect(&invitation_update).to change{ Invitation.count }.by(0)
+      expect(response).to redirect_to @invitation
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    context 'reciever declines invitation' do
+      it 'is successful' do
+        expect{ delete(:destroy, id: @invitation.id) }
+          .to change{ Invitation.count }.by(-1)
+        expect(response).to redirect_to users_me_path
+      end
+    end
+
+    context 'inviter cancels invitation' do
+      it 'is successful' do
+        sign_out @invitation.receiver
+        sign_in @invitation.inviter
+
+        expect{ delete(:destroy, id: @invitation.id) }
+          .to change{ Invitation.count }.by(-1)
+        expect(response).to redirect_to @invitation.sender
+      end
+    end
+  end
+
+  describe 'GET #join' do
+    context 'reciever is already on a team' do
+      it 'does not add current user to a new team' do
+        user = create(:user, team: create(:team))
+        invitation = create(:invitation, receiver: user)
+
+        sign_out @invitation.receiver
+        sign_in user
+        get(:join, id: invitation.id)
+
+        expect(response).to redirect_to users_me_path
+      end
+
+      context 'reciever is not yet on a team' do
+        it 'adds user to invitation attached to team' do
+          get(:join, id: @invitation.id)
+
+          expect(response).to redirect_to @invitation.sender
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -16,10 +16,19 @@ FactoryGirl.define do
   end
 
   factory :team do
-    name "Team AwesomeSauce"
+    name 'Team AwesomeSauce'
   end
 
   factory :unit do
     number_occupants 1
+  end
+
+  factory :invitation do
+    email 'example@example.com'
+    association :receiver, factory: :user, first_name: 'Receiver'
+    association :sender, factory: :team
+    association :inviter, factory: :user, first_name: 'Inviter'
+    token Digest::SHA1.hexdigest([Time.now].join)
+    mssg 'I would love for you to join the team!'
   end
 end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -28,7 +28,7 @@ FactoryGirl.define do
     association :receiver, factory: :user, first_name: 'Receiver'
     association :sender, factory: :team
     association :inviter, factory: :user, first_name: 'Inviter'
-    token Digest::SHA1.hexdigest([Time.now].join)
+    token Digest::SHA1.hexdigest(Time.now.to_s)
     mssg 'I would love for you to join the team!'
   end
 end


### PR DESCRIPTION
A lot of just happy paths in this spec. Not a lot of validation failures to work with. 

Please note that I used a lambda purely for code cleanliness. It looked pretty gross beforehand. Separating that functionality made everything look nicer.

Also, there will be a deprecation warning related to action mailer that will pop up when the test suite is run. I will open an issue for this.

Also also, I had to change one thing in the controller to make things work. 'users/me' doesn't contain a leading '/' so I changed it using the path helper 😄. Before, I was getting the path 'http://test.hostusers/me', which doesn't look correct.
