### PR TITLE
delete teams#destroy and test example, add test examples for teams#leaving

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -80,13 +80,11 @@ class TeamsController < ApplicationController
     @user = current_user
     @user.team = nil
     @user.save
+    @team.destroy if @team.users.empty?
+
     respond_to do |format|
       format.html { redirect_to '/users/me', notice: 'You have left the team.' }
       format.json { render :show, status: :ok, location: @user }
-    end
-    # Want team to destroy itself if there are no users. Having weird issues -mahtai
-    if @team.users.length == 0
-      @team.destroy
     end
   end
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_team, only: [:show, :edit, :update, :destroy, :invite, :inviting, :leave]
+  before_action :set_team, only: [:show, :edit, :update, :invite, :inviting, :leave]
 
   # GET /teams
   # GET /teams.json
@@ -51,16 +51,6 @@ class TeamsController < ApplicationController
         format.html { render :edit }
         format.json { render json: @team.errors, status: :unprocessable_entity }
       end
-    end
-  end
-
-  # DELETE /teams/1
-  # DELETE /teams/1.json
-  def destroy
-    @team.destroy
-    respond_to do |format|
-      format.html { redirect_to teams_url, notice: 'Team was successfully destroyed.' }
-      format.json { head :no_content }
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,11 +5,11 @@ Rails.application.routes.draw do
       get 'join'
     end
   end
-  
+
   resources :bills do
     collection { get 'comparison' }
   end
-  resources :teams do
+  resources :teams, except: :destroy do
     member do
       get 'invite'
       get 'add'

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -113,4 +113,31 @@ describe TeamsController do
       end
     end
   end
+
+  describe 'GET #leave' do
+    let(:team)  { create(:team) }
+    let(:user1) { create(:user, team: team) }
+    let(:expectation) { expect{ get(:leave, id: team.id) } }
+
+    before(:each) { sign_in user1 }
+
+    context 'team has more than one member' do
+      it 'does not destroy team' do
+        create(:user, team: team)
+
+        expectation.to change{ team.users.count }.by(-1)
+        expectation.to_not change{ Team.count }
+        expect(response).to redirect_to users_me_path
+      end
+    end
+
+    context 'team has a single member' do
+      it 'destroys team when last member leaves' do
+        expectation.to change{ Team.count }.by(-1)
+        expect(response).to redirect_to users_me_path
+      end
+    end
+  end
 end
+
+# Team.find(team.id)

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -95,25 +95,6 @@ describe TeamsController do
     end
   end
 
-  describe 'DELETE #destroy' do
-    context 'user is signed in' do
-      it 'is successful' do
-        user = create(:user)
-        sign_in user
-
-        expect{ delete(:destroy, id: @team.id) }.to change{ Team.count }.by(-1)
-        expect(response).to redirect_to teams_url
-      end
-    end
-
-    context 'user is not signed in' do
-      it 'is not successful' do
-        expect{ delete(:destroy, id: @team.id) }.to change{ Team.count }.by(0)
-        expect(response).to redirect_to new_user_session_path
-      end
-    end
-  end
-
   describe 'GET #leave' do
     let(:team)  { create(:team) }
     let(:user1) { create(:user, team: team) }
@@ -139,5 +120,3 @@ describe TeamsController do
     end
   end
 end
-
-# Team.find(team.id)


### PR DESCRIPTION
The only way a team would be destroyed is when a the last team member leaves, and not through another mechanism allowed by a user.

completes issue #100
