### PR TITLE
Hiding signup link for logged-in users

### DIFF
--- a/app/controllers/graph_controller.rb
+++ b/app/controllers/graph_controller.rb
@@ -1,4 +1,5 @@
 class GraphController < ApplicationController
   def index
+    @user = current_user
   end
 end

--- a/app/views/graph/index.html.erb
+++ b/app/views/graph/index.html.erb
@@ -7,7 +7,7 @@
 <div class="row">
   <div class="small-11 small-centered columns">
     <h2>You can save money on your energy bill</h2>
-
+    <% unless @user %>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= devise_error_messages! %>
 
@@ -32,6 +32,7 @@
       <div class="actions">
         <%= f.submit "Sign up and learn how", class: "button expand" %>
       </div>
-    <% end %>
+      <% end %>
+      <% end %>
   </div>
 </div>


### PR DESCRIPTION
Hiding the signup form on the graph/index page from users who have already logged in.
Fixes #125 
