### PR TITLE
Unit creator added to unit

### DIFF
--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -1,6 +1,6 @@
 class UnitsController < ApplicationController
   before_action :set_unit, only: [:authorize_user, :show, :edit, :update, :destroy]
-  before_action :authorize_user, only: [:show, :edit, :update, :destroy]
+  before_action :authorize_user, only: [:show, :edit, :update]
 
   # GET /units/1
   # GET /units/1.json
@@ -22,7 +22,7 @@ class UnitsController < ApplicationController
   # POST /units.json
   def create
     @unit = Unit.new(unit_params)
-
+    @user = current_user
     respond_to do |format|
       if creating_new_user_building?
         @user_building = UserBuilding.new(user_building_params)
@@ -30,6 +30,7 @@ class UnitsController < ApplicationController
           @unit.user_building = @user_building
           @unit.save
           @user_building.save
+          @user.unit_id = @unit.id
           format.html { redirect_to @unit, notice: 'Unit was successfully created.' }
           format.json { render :show, status: :created, location: @unit }
         else
@@ -40,6 +41,7 @@ class UnitsController < ApplicationController
       else
         @user_building = UserBuilding.find_by(id: params[:unit][:user_building_id])
         if @user_building && @unit.save
+          @user.unit_id = @unit.id
           format.html { redirect_to @unit, notice: 'Unit was successfully created.' }
           format.json { render :show, status: :created, location: @unit }
         else
@@ -63,7 +65,7 @@ class UnitsController < ApplicationController
       end
     end
   end
-
+  
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_unit

--- a/app/views/units/show.html.erb
+++ b/app/views/units/show.html.erb
@@ -35,4 +35,17 @@
   <%= @unit.number_occupants %>
 </p>
 
+<p>
+  <strong>Occupants:</strong>
+  <table>
+    <tbody>
+      <% @unit.users.each do |user| %>
+      <tr>
+	<td><%= user.first_name %></td>
+	<td><%= user.last_name %></td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</p>  
 <%= link_to 'Edit', edit_unit_path(@unit) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,7 +33,7 @@
 <p>
   <strong>Unit:</strong>
   <% if @user.unit.present? %>
-  <%= @user.unit %>
+  <%= link_to @user.unit.user_building.address, @user.unit %>
   <% else %>
   <%= link_to 'Create', new_unit_path %>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,21 +21,17 @@
 </p>
 
 <p>
-  <strong>Street address:</strong>
-  <%= @user.street_address %>
-</p>
-
-<p>
   <strong>Phone:</strong>
   <%= @user.phone %>
 </p>
 
 <p>
-  <strong>Unit:</strong>
+  <strong>Address:</strong>
   <% if @user.unit.present? %>
-  <%= link_to @user.unit.user_building.address, @user.unit %>
+  <%= link_to @user.unit.user_building.address + ', apt. ' + @user.unit.unit_number.to_s, @user.unit %>
   <% else %>
-  <%= link_to 'Create', new_unit_path %>
+  <%= @user.street_address %><br/>
+  <%= link_to 'Create a unit', new_unit_path %>
   <% end %>
 </p>
 


### PR DESCRIPTION
The problem with creating a unit is that the creator of the unit wasn't necessarily in the unit, so the authorization never passed. So I modified the unit#create action to automatically add the current user to the unit. I also modified the unit#show and user#show views to better indicate that a given unit contains a given user.
Note: There is still no way to join a unit other than creating it. This should be dealt with at some point, but this is still better than before, when there wasn't a way to join a unit at all.
