### PR TITLE
Userbuildinglink

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -5,7 +5,7 @@ module UsersHelper
       completeness = ""
       tot += 25 unless user.first_name.nil? || user.first_name.empty?
       tot += 25 unless  user.last_name.nil? || user.last_name.empty?
-      tot += 35 unless user.street_address.nil? || user.street_address.empty?
+      tot += 35 if user.unit.present?
       tot += 15 unless user.phone.nil? || user.phone.empty?
 
       if tot == 0

--- a/app/views/units/show.html.erb
+++ b/app/views/units/show.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <strong>Address:</strong>
-  <%= @unit.user_building.address %>
+  <%= link_to @unit.user_building.address, @unit.user_building %>
 </p>
 
 <p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,7 +31,7 @@
 
 <p>
   <strong>Street address:</strong>
-  <%= @user.unit.user_building.address if @user.unit.present? %>
+  <%= link_to @user.unit.user_building.address, @user.unit.user_building if @user.unit.present? %>
 </p>
 
 <p>


### PR DESCRIPTION
Made the building address a link to the building on both user and unit pages, changed the profile completeness meter to look for units rather than user-inserted street addresses.
