### PR TITLE
set the domain for the actionmailer production version

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,8 +82,9 @@ Rails.application.configure do
     :password => ENV['SENDGRID_PASSWORD'],
     :address => "smtp.sendgrid.net",
     :port => 587,
+    :domain  => 'yourapp.heroku.com',
     :authentication => :plain,
-    :enable_starttls_auto => true
+    :enable_starttls_auto => true,
   }
 
   config.action_mailer.default_url_options = { :host => 'fathomless-mountain-9153.herokuapp.com' }


### PR DESCRIPTION
set the domain for when the password reset option is selected. According to the SendGrid documentation, a default domain is needed for production. 
