### PR TITLE
Google auth scope

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,8 +82,9 @@ Rails.application.configure do
     :password => ENV['SENDGRID_PASSWORD'],
     :address => "smtp.sendgrid.net",
     :port => 587,
+    :domain  => 'yourapp.heroku.com',
     :authentication => :plain,
-    :enable_starttls_auto => true
+    :enable_starttls_auto => true,
   }
 
   config.action_mailer.default_url_options = { :host => 'fathomless-mountain-9153.herokuapp.com' }

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -2,7 +2,10 @@
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
   # OmniAuth providers
-  config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"]
+  config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], {
+
+    scope: "email"
+  }
   #require "omniauth-google-oauth2"
 
   # The secret key used by Devise. Devise uses this key to generate


### PR DESCRIPTION
The Google authentication didn't appear to have a scope set. According to the documentation online, a scope is always needed. The scope was set to email in this fix.
