### PR TITLE
Fixes issue #199 (Fix obscure bug in accept existing invitation flow)

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -94,11 +94,16 @@ class TeamsController < ApplicationController
 
 
   def accept_invite
-    #if user hits reload and resubmits form there is an error due to nil invited_by
-    current_user.accept_invite
-    @team = current_user.team
-    flash[:notice] = "You have joined #{current_user.team.name}!"
-    render :show
+    if current_user.invited_by_id
+      current_user.accept_invite
+      @team = current_user.team
+      flash[:notice] = "You have joined #{current_user.team.name}!"
+      redirect_to team_path(@team)
+    elsif current_user.team
+      redirect_to team_path(current_user.team)
+    else
+      redirect_to :root
+    end
   end
 
   def decline_invite


### PR DESCRIPTION
@veddster I added a check at the beginning of accept_invite, so that the code within current_user.accept_invite only gets run if the inviter_id exists. Also switched the render :show to a redirect, so the flash notice only appears once. 

Fixes issue #199 
