### PR TITLE
Update ruby version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2.4
+FROM ruby:2.2.5
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
Why:
- It was not possible to run the app or any rake task otherwise

This change addresses the need by:
- Update the Dockerfile to install version 2.2.5 of ruby, which is the one
  specificed in the Gemfile
