### PR TITLE
Remove modernizr

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
     <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600|Ubuntu:400,500' rel='stylesheet' type='text/css'>
 
     <%= stylesheet_link_tag    "application", debug: false %>
-    <%= javascript_include_tag "vendor/modernizr" %>
     <%= javascript_include_tag "application", 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
   </head>


### PR DESCRIPTION
We are not using modernizr anymore since it was part of foundation and we removed foundation. This will remove a javascript console error.
