### PR TITLE
Fix for issue #263 (Why do you need the Bill Due Date)

### DIFF
--- a/app/views/bills/_form.html.erb
+++ b/app/views/bills/_form.html.erb
@@ -13,7 +13,7 @@
 
 <div class="billFields">
   <div class="field">
-    <%= f.label :bill_received, "Date Bill is Due" %><br>
+    <%= f.label :bill_received, "Bill Date" %><br>
     <%= f.text_field :bill_received, :id=> "datepicker" %>
   </div>
 

--- a/spec/features/user_can_create_new_bill_spec.rb
+++ b/spec/features/user_can_create_new_bill_spec.rb
@@ -10,7 +10,7 @@ feature "user can add a new bill" do
 
     expect(page).to have_content "Sign up to learn how to save money on your energy bill:"
     expect(page).to have_css "svg#graph"
-    expect(page).to_not have_content "Date Bill is Due"
+    expect(page).to_not have_content "Bill Date"
   end
 
   scenario "user does not enter any bill information" do


### PR DESCRIPTION
This PR renames "Date Bill is Due" to "Bill Date" in the Add Bill view, as well as the rspec test.
