### PR TITLE
Add task to destroy guest users after one week

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,9 @@ class User < ActiveRecord::Base
 
   after_invitation_accepted :accept_invite
 
+  scope :guests, -> { where(first_name: 'guest') }
+  scope :stale_guests, -> { guests.where('created_at < ?', 1.week.ago) }
+
   def area_code
     self.phone ? self.phone.slice(0,3) : nil
   end

--- a/lib/tasks/destroy_stale_guest_users.rake
+++ b/lib/tasks/destroy_stale_guest_users.rake
@@ -1,0 +1,3 @@
+task destroy_stale_guest_users: :environment do
+  User.stale_guests.destroy_all
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -113,7 +113,8 @@ describe User do
     let!(:not_guest) { create :user, first_name: 'not guest' }
     subject { User.guests }
 
-    it { is_expected.to match_array([guest]) }
+    it { is_expected.to include(guest) }
+    it { is_expected.not_to include(not_guest) }
   end
 
   describe '.stale_guests' do
@@ -122,6 +123,8 @@ describe User do
     let!(:not_guest) { create :user, first_name: 'not guest', created_at: 2.weeks.ago }
     subject { User.stale_guests }
 
-    it { is_expected.to match_array([stale_guest]) }
+    it { is_expected.to include(stale_guest) }
+    it { is_expected.not_to include(not_stale) }
+    it { is_expected.not_to include(not_guest) }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -107,4 +107,21 @@ describe User do
       expect(user.most_recent_bills(2)).to be_a(Array)
     end
   end
+
+  describe '.guests' do
+    let!(:guest) { create :user, first_name: 'guest' }
+    let!(:not_guest) { create :user, first_name: 'not guest' }
+    subject { User.guests }
+
+    it { is_expected.to match_array([guest]) }
+  end
+
+  describe '.stale_guests' do
+    let!(:stale_guest) { create :user, first_name: 'guest', created_at: 2.weeks.ago }
+    let!(:not_stale) { create :user, first_name: 'guest' }
+    let!(:not_guest) { create :user, first_name: 'not guest', created_at: 2.weeks.ago }
+    subject { User.stale_guests }
+
+    it { is_expected.to match_array([stale_guest]) }
+  end
 end


### PR DESCRIPTION
Issue #256.

This destroys users that were created more than one week ago. Is there a way to determine if a user has been inactive, so that we are not destroying active guest users? Is there any reason an active user would remain a guest?

I believe this will not destroy units associated with guest users. Is that the correct behavior?

I can write a spec for the task if necessary.

This does not add any method of scheduling the task. The issue mentioned sidekiq, but that seems like overkill just to run a single job per week. The best option probably depends mostly on how this is being hosted.